### PR TITLE
Clean up parses to make them more safe

### DIFF
--- a/Source/DynamicBatteryStorage/Handlers/GenericFieldDataHandler.cs
+++ b/Source/DynamicBatteryStorage/Handlers/GenericFieldDataHandler.cs
@@ -53,7 +53,7 @@ namespace DynamicBatteryStorage
       double results = 0d;
       if (editorField != null)
       {
-        double.TryParse(editorField.GetValue(pm).ToString(), out results);
+        double.TryParse(editorField.GetValue(pm)?.ToString(), out results);
       }
       return results * editorValueScalar;
     }
@@ -62,7 +62,7 @@ namespace DynamicBatteryStorage
       double results = 0d;
       if (flightField != null)
       {
-        double.TryParse(flightField.GetValue(pm).ToString(), out results);
+        double.TryParse(flightField.GetValue(pm)?.ToString(), out results);
       }
       return results * flightValueScalar;
     }

--- a/Source/DynamicBatteryStorage/Handlers/KopernicusPowerHandlers.cs
+++ b/Source/DynamicBatteryStorage/Handlers/KopernicusPowerHandlers.cs
@@ -28,11 +28,7 @@
 
     protected override double GetValueFlight()
     {
-      double results = 0d;
-      if (double.TryParse(pm.Fields.GetValue("currentOutput").ToString(), out results))
-      {
-        return results;
-      }
+      Utils.TryGetField(pm, "currentOutput", out double results);
       return results;
     }
   }

--- a/Source/DynamicBatteryStorage/Handlers/RealBatteryPowerHandlers.cs
+++ b/Source/DynamicBatteryStorage/Handlers/RealBatteryPowerHandlers.cs
@@ -25,7 +25,7 @@ namespace DynamicBatteryStorage
     }
     protected override double GetValueFlight()
     {
-      double.TryParse(pm.Fields.GetValue("lastECpower").ToString(), out double results);
+      Utils.TryGetField(pm, "lastECpower", out double results);
       if (results > 0)
       {
         producer = false;

--- a/Source/DynamicBatteryStorage/Handlers/ScanSatPowerHandler.cs
+++ b/Source/DynamicBatteryStorage/Handlers/ScanSatPowerHandler.cs
@@ -25,7 +25,7 @@
     }
     protected override double GetValueFlight()
     {
-      bool.TryParse(pm.Fields.GetValue("scanning").ToString(), out bool isScanning);
+      Utils.TryGetField(pm, "scanning", out bool isScanning);
       if (isScanning)
       {
         return -resource.rate;

--- a/Source/DynamicBatteryStorage/Handlers/WDSPPowerHandlers.cs
+++ b/Source/DynamicBatteryStorage/Handlers/WDSPPowerHandlers.cs
@@ -29,10 +29,7 @@ namespace DynamicBatteryStorage
         }
         protected override double GetValueFlight()
         {
-            if (double.TryParse(pm.Fields.GetValue("currentOutput").ToString(), out double results))
-            {
-                return results;
-            }
+            Utils.TryGetField(pm, "currentOutput", out double results);
             return results;
 
         }

--- a/Source/DynamicBatteryStorage/Settings.cs
+++ b/Source/DynamicBatteryStorage/Settings.cs
@@ -212,10 +212,10 @@ namespace DynamicBatteryStorage
     public static List<String> SupportedModules(ResourcesSupported resourceType)
     {
       List<string> supportedModules = new List<string>();
-      for (int i = 0; i < HandlerPartModuleData.Count; i++)
+      for (int i = 0; i < HandlerPartModuleData?.Count; i++)
       {
-        if (HandlerPartModuleData[i].resourceType == resourceType)
-          supportedModules.Add(HandlerPartModuleData[i].handledModule);
+        if (HandlerPartModuleData[i]?.resourceType == resourceType)
+          supportedModules.Add(HandlerPartModuleData[i]?.handledModule);
       }
       return supportedModules;
     }

--- a/Source/DynamicBatteryStorage/Utils.cs
+++ b/Source/DynamicBatteryStorage/Utils.cs
@@ -49,44 +49,25 @@ namespace DynamicBatteryStorage
 
     public static bool TryGetField(PartModule pm, string fieldName, out bool result)
     {
-      result = false;
-      var field = pm.Fields.GetValue(fieldName);
-      if (field != null)
-      {
-        if (bool.TryParse(field.ToString(), out result))
-        {
-          return true;
-        }
-      }
-      return false;
+        result = false;
+        string field = pm?.Fields?.GetValue(fieldName)?.ToString();
+        return bool.TryParse(field, out result);
     }
 
     public static bool TryGetField(PartModule pm, string fieldName, out double result)
     {
-      result = 0d;
-      var field = pm.Fields.GetValue(fieldName);
-      if (field != null)
-      {
-        if (double.TryParse(field.ToString(), out result))
-        {
-          return true;
-        }
-      }
-      return false;
+        result = 0d;
+        string field = pm?.Fields?.GetValue(fieldName)?.ToString();
+        return double.TryParse(field, out result);
     }
+    
     public static bool TryGetField(PartModule pm, string fieldName, out float result)
     {
-      result = 0f;
-      var field = pm.Fields.GetValue(fieldName);
-      if (field != null)
-      {
-        if (float.TryParse(field.ToString(), out result))
-        {
-          return true;
-        }
-      }
-      return false;
+        result = 0f;
+        string field = pm?.Fields?.GetValue(fieldName)?.ToString();
+        return float.TryParse(field, out result);
     }
+
     public static bool TryParseEnum<T>(string str, bool caseSensitive, out T value) where T : struct
     {
       // Can't make this a type constraint...

--- a/Source/DynamicBatteryStorage/Utils.cs
+++ b/Source/DynamicBatteryStorage/Utils.cs
@@ -101,7 +101,7 @@ namespace DynamicBatteryStorage
       {
         result = parent.FindDeepChild(name).GetComponent<T>();
       }
-      catch (NullReferenceException e)
+      catch (NullReferenceException)
       {
         Debug.LogError($"Couldn't find {name} in children of {parent.name}");
       }


### PR DESCRIPTION
User Xenon [recently reported](https://discord.com/channels/319857228905447436/331813459417235457/1421590466708635712) on the KSP-RO server that their log was being spammed with NREs. This is the result of some unsafe ToString() calls to fields that might not exist. (specifically the one for `KopernicusSolarPanelPowerHandler`, but I noticed the same mistakes in other classes)

I've cleaned up the Utils TryGetField methods a bit, and made some other spots use TryGetField instead of doing their own thing