### PR TITLE
Disable DBS if RO is detected

### DIFF
--- a/Source/DynamicBatteryStorage/Settings.cs
+++ b/Source/DynamicBatteryStorage/Settings.cs
@@ -73,6 +73,10 @@ namespace DynamicBatteryStorage
       ConfigNode settingsNode;
 
       DetectMods();
+      if (Settings.Enabled == false)
+      {
+          return;
+      }
 
       Utils.Log("[Settings]: Started loading", Utils.LogType.Settings);
       if (GameDatabase.Instance.ExistsConfigNode(CONFIG_NODE_NAME))

--- a/Source/DynamicBatteryStorage/Settings.cs
+++ b/Source/DynamicBatteryStorage/Settings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using UniLinq;
@@ -143,6 +143,13 @@ namespace DynamicBatteryStorage
         {
           Utils.Log("[Settings]: Kerbalism detected. DBS will disable itself.", Utils.LogType.Any);
           Settings.Enabled = false;
+          break;
+        }
+        if (a.name.StartsWith("RealismOverhaul", StringComparison.Ordinal))
+        {
+          Utils.Log("[Settings]: Realism Overhaul detected. DBS will disable itself.", Utils.LogType.Any);
+          Settings.Enabled = false;
+          break;
         }
         // Search for kopernicus
         if (a.name.StartsWith("Kopernicus", StringComparison.Ordinal))
@@ -156,13 +163,13 @@ namespace DynamicBatteryStorage
           var msObj = starType.GetField("UseMultiStarLogic",
             BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy).GetValue(null);
           KopernicusMultiStar = (bool)msObj;
-          Utils.Log($"[Settings] Kopernicus Multi Star Logic is {KopernicusMultiStar}",Utils.LogType.Any);
+          Utils.Log($"[Settings] Kopernicus Multi Star Logic is {KopernicusMultiStar}", Utils.LogType.Any);
         }
         // Search for wdsp
         if (a.name.StartsWith("WeatherDrivenSolarPanel", StringComparison.Ordinal))
         {
           WeatherDrivenSolarPanel = true;
-          Utils.Log($"[Settings] Weather Dependent Solar Panel logic is  Multi Star Logic is {WeatherDrivenSolarPanel}", Utils.LogType.Any);
+          Utils.Log($"[Settings] Weather Dependent Solar Panel logic is {WeatherDrivenSolarPanel}", Utils.LogType.Any);
         }
           
       }


### PR DESCRIPTION
Fix https://github.com/post-kerbin-mining-corporation/DynamicBatteryStorage/pull/114#issuecomment-3342052026.

As RO will [nuke DBS](https://github.com/KSP-RO/RealismOverhaul/blob/master/Source/DynamicBatteryStorageNuker.cs) if it finds it, there is no reason to keep DBS enabled if RO is installed.

Additionally, break out of the loop immediately, and fix a typo in the log for WeatherDrivenSolarPanel.