### PR TITLE
Defer work in vessel modules until the data is actually needed

### DIFF
--- a/Source/DynamicBatteryStorage/Data/VesselDataManager.cs
+++ b/Source/DynamicBatteryStorage/Data/VesselDataManager.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 namespace DynamicBatteryStorage
 {
@@ -7,51 +8,55 @@ namespace DynamicBatteryStorage
   /// </summary>
   public class VesselDataManager : VesselModule
   {
-    #region Accessors
-
-    public VesselElectricalData ElectricalData { get { return electricalData; } }
-    public bool Ready { get { return dataReady; } }
-
-    #endregion
-
-    #region PrivateVariables
-
-    bool dataReady = false;
-    bool vesselLoaded = false;
+    public VesselElectricalData ElectricalData => GetElectricalData();
 
     VesselElectricalData electricalData;
-    #endregion
 
-    protected override void OnStart()
+    VesselElectricalData GetElectricalData()
     {
-      base.OnStart();
+      if (electricalData != null)
+        return electricalData;
 
-      // These events need to trigger a refresh
-      GameEvents.onVesselGoOnRails.Add(new EventData<Vessel>.OnEvent(RefreshVesselData));
-      GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(RefreshVesselData));
-    }
-
-    void OnDestroy()
-    {
-      // Clean up events when the item is destroyed
-      GameEvents.onVesselGoOnRails.Remove(RefreshVesselData);
-      GameEvents.onVesselWasModified.Remove(RefreshVesselData);
-    }
-
-    void FixedUpdate()
-    {
-      if (HighLogic.LoadedSceneIsFlight && !dataReady)
+      try
       {
-        if (!vesselLoaded && FlightGlobals.ActiveVessel == vessel)
-        {
-          RefreshVesselData();
-          vesselLoaded = true;
-        }
-        if (vesselLoaded && FlightGlobals.ActiveVessel != vessel)
-        {
-          vesselLoaded = false;
-        }
+        RefreshVesselData();
       }
+      catch (Exception e)
+      {
+        Utils.Error("RefreshVesselData threw an exception");
+        Debug.LogException(e);
+        return null;
+      }
+
+      return electricalData;
+    }
+
+    // This module is only active in the flight scene for loaded vessels.
+    public override bool ShouldBeActive()
+    {
+      if (!HighLogic.LoadedSceneIsFlight)
+        return false;
+
+      return vessel.loaded;
+    }
+
+    // Use OnEnable and OnDisable because ShouldBeActive will cause us to switch
+    // between being enabled and disabled in response to events.
+    void OnEnable()
+    {
+      GameEvents.onVesselGoOnRails.Add(RefreshVesselData);
+      GameEvents.onVesselWasModified.Add(InvalidateVesselData);
+
+      if (vessel == FlightGlobals.ActiveVessel)
+        RefreshVesselData();
+    }
+
+    void OnDisable()
+    {
+      GameEvents.onVesselGoOnRails.Remove(RefreshVesselData);
+      GameEvents.onVesselWasModified.Remove(InvalidateVesselData);
+
+      electricalData = null;
     }
 
     /// <summary>
@@ -59,22 +64,29 @@ namespace DynamicBatteryStorage
     /// </summary>
     protected void RefreshVesselData(Vessel eventVessel)
     {
-      if (vessel != null && vessel.loaded)
-      {
-        Utils.Log(String.Format("[{0}]: Refreshing VesselData from Vessel event", this.GetType().Name), Utils.LogType.VesselData);
-        RefreshVesselData();
-      }
+      if (vessel != eventVessel)
+        return;
+      if (vessel == null || !vessel.loaded)
+        return;
+
+      if (Settings.DebugVesselData)
+        Utils.Log($"[{GetType().Name}]: Refreshing VesselData from Vessel event", Utils.LogType.VesselData);
+      RefreshVesselData();
     }
+
     /// <summary>
-    /// Referesh the data, given a ConfigNode event
+    /// Invalidate the current electrical data, given a vessel event.
     /// </summary>
-    protected void RefreshVesselData(ConfigNode node)
+    /// <param name="eventVessel"></param>
+    protected void InvalidateVesselData(Vessel eventVessel)
     {
-      if (vessel != null && vessel.loaded)
-      {
-        Utils.Log(String.Format("[{0}]: Refreshing VesselData from save node event", this.GetType().Name), Utils.LogType.VesselData);
-        RefreshVesselData();
-      }
+      if (vessel != eventVessel)
+        return;
+
+      electricalData = null;
+
+      if (Settings.DebugVesselData)
+        Utils.Log($"[{GetType().Name}]: Invalidated VesselData from Vessel event", Utils.LogType.VesselData);
     }
 
     /// <summary>
@@ -86,8 +98,9 @@ namespace DynamicBatteryStorage
         return;
 
       electricalData = new VesselElectricalData(vessel.Parts);
-      dataReady = true;
-      Utils.Log(String.Format("Dumping electrical database: \n{0}", electricalData.ToString()), Utils.LogType.VesselData);
+
+      if (Settings.DebugVesselData)
+        Utils.Log($"Dumping electrical database: \n{electricalData}", Utils.LogType.VesselData);
     }
   }
 }

--- a/Source/DynamicBatteryStorage/DynamicBatteryStorage.cs
+++ b/Source/DynamicBatteryStorage/DynamicBatteryStorage.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace DynamicBatteryStorage
@@ -41,34 +38,70 @@ namespace DynamicBatteryStorage
     PartResource bufferStorage;
     Part bufferPart;
 
-    protected override void OnAwake()
+    // Only run on loaded vessels in the flight scene.
+    public override bool ShouldBeActive()
     {
-      base.OnAwake();
-      enabled = Settings.Enabled;
+      if (!Settings.Enabled)
+        return false;
+
+      if (!HighLogic.LoadedSceneIsFlight)
+        return false;
+
+      return vessel.loaded;
     }
-    public override Activation GetActivation()
+
+    void OnEnabled()
     {
-      if (Settings.Enabled)
+      GameEvents.onVesselGoOnRails.Add(CalculateElectricalData);
+      GameEvents.onVesselWasModified.Add(InvalidateElectricalData);
+    }
+
+    void OnDisable()
+    {
+      GameEvents.onVesselGoOnRails.Add(CalculateElectricalData);
+      GameEvents.onVesselWasModified.Add(InvalidateElectricalData);
+    }
+
+    void FixedUpdate()
+    {
+      if (!vesselLoaded)
       {
-        return Activation.Always;
+        vesselData = vessel.GetComponentCached(ref vesselData);
+        if (!vesselData)
+        {
+          Utils.Error(CreateVesselLogString("Could not find vessel data manager"));
+          return;
+        }
+
+        CalculateElectricalData();
+        vesselLoaded = true;
       }
+
+      analyticMode = TimeWarp.CurrentRate < timeWarpLimit;
+      if (!analyticMode)
+        DoLowWarpSimulation();
       else
-        return Activation.Never;
+        DoHighWarpSimulation();
     }
-    protected override void OnStart()
+
+    protected void InvalidateElectricalData(Vessel eventVessel)
     {
-      base.OnStart();
+      if (vessel != eventVessel)
+        return;
 
-      if (!Settings.Enabled) return;
+      vesselLoaded = false;
+      bufferPart = null;
+      bufferStorage = null;
+    }
 
-      bufferScale = Settings.BufferScaling;
-      timeWarpLimit = Settings.TimeWarpLimit;
+    protected void CalculateElectricalData(Vessel eventVessel)
+    {
+      if (vessel != eventVessel)
+        return;
+      if (!vessel.loaded)
+        return;
 
-      GameEvents.onVesselDestroy.Add(new EventData<Vessel>.OnEvent(CalculateElectricalData));
-      GameEvents.onVesselGoOnRails.Add(new EventData<Vessel>.OnEvent(CalculateElectricalData));
-      GameEvents.onVesselWasModified.Add(new EventData<Vessel>.OnEvent(CalculateElectricalData));
-
-      FindDataManager();
+      CalculateElectricalData();
     }
 
     protected override void OnSave(ConfigNode node)
@@ -78,58 +111,15 @@ namespace DynamicBatteryStorage
       base.OnSave(node);
     }
 
-    void OnDestroy()
-    {
-      GameEvents.onVesselDestroy.Remove(CalculateElectricalData);
-      GameEvents.onVesselGoOnRails.Remove(CalculateElectricalData);
-      GameEvents.onVesselWasModified.Remove(CalculateElectricalData);
-    }
-
-    void FindDataManager()
-    {
-      vesselData = vessel.GetComponent<VesselDataManager>();
-      if (!vesselData)
-      {
-        Utils.Error(CreateVesselLogString("Could not find vessel data manager"));
-      }
-    }
-
-    void FixedUpdate()
-    {
-      if (HighLogic.LoadedSceneIsFlight)
-      {
-        if (!vesselLoaded && FlightGlobals.ActiveVessel == vessel)
-        {
-          FindDataManager();
-          CalculateElectricalData();
-          vesselLoaded = true;
-        }
-        if (vesselLoaded && FlightGlobals.ActiveVessel != vessel)
-        {
-          vesselLoaded = false;
-        }
-        if (TimeWarp.CurrentRate < timeWarpLimit)
-        {
-          analyticMode = false;
-          DoLowWarpSimulation();
-        }
-        else
-        {
-          analyticMode = true;
-          DoHighWarpSimulation();
-        }
-      }
-    }
-
     /// <summary>
     /// Runs the compensation at low warp. This typically means do nothing
     /// </summary>
     protected void DoLowWarpSimulation()
     {
-      if (bufferStorage != null && bufferStorage.maxAmount != originalMax)
-      {
-        bufferStorage.maxAmount = originalMax;
-      }
+      if (bufferStorage == null)
+        return;
+
+      bufferStorage.maxAmount = originalMax;
     }
 
     /// <summary>
@@ -199,22 +189,6 @@ namespace DynamicBatteryStorage
         vessel.GetConnectedResourceTotals(PartResourceLibrary.ElectricityHashcode, out amount, out maxAmount);
         totalEcMax = maxAmount;
         CreateBufferStorage();
-      }
-    }
-
-
-    protected void CalculateElectricalData(Vessel eventVessel)
-    {
-      if (vessel != null && vessel.loaded)
-      {
-        CalculateElectricalData();
-      }
-    }
-    protected void CalculateElectricalData(ConfigNode node)
-    {
-      if (vessel != null && vessel.loaded)
-      {
-        CalculateElectricalData();
       }
     }
 


### PR DESCRIPTION
DBS has shown up in my profiles for a while in cases where a vessel gets modified (crashing, launch clamps decoupling, etc.) For large ships DBS can easily account for 15-20s of a 50s frame. This PR improves that from 15-20s to sub-100ms for an 1000 part ship that is in the process of exploding.

The main changes here are:
* `VesselDataManager` and `ModuleDynamicBatteryStorage` no longer refresh their internal data in `onVesselWasModified`. Instead, they invalidate their current data and recalculate either the next time it is needed, or on the next FixedUpdate, respectively.
* The refresh event handlers for those same vessel modules now only run if the event is for their vessel, instead of running any time that event is fired. This brings down the amount of work that needs to be done to `O(n)` instead of `O(n^2)`.

There are also a bunch of other minor changes:
* Both modules now use `ShouldBeActive` to disable themselves when there is nothing for them to do.
* Adding/removing event handlers has been moved to `OnEnable`/`OnDisable` to account for this.
* `VesselDataManager` no longer has a `FixedUpdate` method. Instead, the vessel data is computed when it is requested.
* Some of the string formats have been moved behind an explicit check that their corresponding log method is enabled, to save some allocations.

Fixes #119 

For some performance numbers, here's what the dottrace profile looked like before these changes (ignore total times, only the relative sizes mean anything)
<img width="1758" height="1104" alt="image" src="https://github.com/user-attachments/assets/56495d03-4055-4642-ab2f-8db642b06f3c" />

And here's what it looks like after. DBS has completely disappeared from the profile. (Again, ignore total times only relative sizes mean anything here)
<img width="1776" height="1021" alt="image" src="https://github.com/user-attachments/assets/5c54b9a7-8d0c-4eb3-980e-a77f8d4c3e1c" />
